### PR TITLE
New: Two new options to set proxmox VM/CT description

### DIFF
--- a/lib/vagrant-proxmox/action/create_vm.rb
+++ b/lib/vagrant-proxmox/action/create_vm.rb
@@ -45,6 +45,11 @@ module VagrantPlugins
         def create_params_qemu(config, env, vm_id)
           network = "#{config.qemu_nic_model},bridge=#{config.qemu_bridge}"
           network = "#{config.qemu_nic_model}=#{get_machine_macaddress(env)},bridge=#{config.qemu_bridge}" if get_machine_macaddress(env)
+          desc = if config.use_plain_description
+                   config.description
+                 else
+                   "#{config.vm_name_prefix}#{env[:machine].name}:#{config.description}"
+                 end
           {
             vmid: vm_id,
             name: env[:machine].config.vm.hostname || env[:machine].name.to_s,
@@ -55,24 +60,34 @@ module VagrantPlugins
             cores: config.qemu_cores,
             memory: config.vm_memory,
             net0: network,
-            description: "#{config.vm_name_prefix}#{env[:machine].name}"
+            description: desc
           }
         end
 
         def create_params_openvz(config, env, vm_id)
+          desc = if config.use_plain_description
+                   config.description
+                 else
+                   "#{config.vm_name_prefix}#{env[:machine].name}:#{config.description}"
+                 end
           {
             vmid: vm_id,
             ostemplate: config.openvz_os_template,
             hostname: env[:machine].config.vm.hostname || env[:machine].name.to_s,
             password: 'vagrant',
             memory: config.vm_memory,
-            description: "#{config.vm_name_prefix}#{env[:machine].name}"
+            description: desc
           }.tap do |params|
             params[:ip_address] = get_machine_ip_address(env) if get_machine_ip_address(env)
           end
         end
 
         def create_params_lxc(config, env, vm_id)
+          desc = if config.use_plain_description
+                   config.description
+                 else
+                   "#{config.vm_name_prefix}#{env[:machine].name}:#{config.description}"
+                 end
           {
             vmid: vm_id,
             ostemplate: config.openvz_os_template,
@@ -80,7 +95,7 @@ module VagrantPlugins
             password: 'vagrant',
             rootfs: "#{config.vm_storage}:#{config.vm_disk_size}",
             memory: config.vm_memory,
-            description: "#{config.vm_name_prefix}#{env[:machine].name}",
+            description: desc,
             cmode: config.lxc_cmode.to_s,
             cpulimit: config.lxc_cpulimit,
             cpuunits: config.lxc_cpuunits,

--- a/lib/vagrant-proxmox/config.rb
+++ b/lib/vagrant-proxmox/config.rb
@@ -289,6 +289,18 @@ module VagrantPlugins
       # @return [Hash]
       attr_accessor :lxc_network_defaults
 
+      # VM/CT description
+      # Container description. Only used on the configuration web interface.
+      #
+      # @return [String]
+      attr_accessor :description
+
+      # Use plain description
+      # disable vagrant_default description prefix
+      #
+      # @return [Boolean]
+      attr_accessor :use_plain_description
+
       def initialize
         @endpoint = UNSET_VALUE
         @selected_node = UNSET_VALUE
@@ -342,6 +354,8 @@ module VagrantPlugins
         @lxc_network_defaults = UNSET_VALUE
         @use_network_defaults = false
         @dry = false
+        @description = UNSET_VALUE
+        @use_plain_description = false
       end
 
       # This is the hook that is called to finalize the object before it is put into use.
@@ -366,6 +380,7 @@ module VagrantPlugins
         @lxc_nameserver = nil if @lxc_nameserver == UNSET_VALUE
         @lxc_tty = 2 if @lxc_tty == UNSET_VALUE
         @pool = nil if @pool == UNSET_VALUE
+        @description = '' if @description == UNSET_VALUE
       end
 
       def validate(_machine)


### PR DESCRIPTION
use_plain_description: disable vagrant_default proxmox description
description: free text field as description of VM/CT