### PR TITLE
Fix: unable to create CT/VM if no pool is defined

### DIFF
--- a/lib/vagrant-proxmox/config.rb
+++ b/lib/vagrant-proxmox/config.rb
@@ -379,7 +379,7 @@ module VagrantPlugins
         @lxc_ostype = nil if @lxc_ostype == UNSET_VALUE
         @lxc_nameserver = nil if @lxc_nameserver == UNSET_VALUE
         @lxc_tty = 2 if @lxc_tty == UNSET_VALUE
-        @pool = nil if @pool == UNSET_VALUE
+        @pool = 'all' if @pool == UNSET_VALUE
         @description = '' if @description == UNSET_VALUE
       end
 


### PR DESCRIPTION
Fixes bug during creating new container/VM when no pool is defined. It will set 'all' as default pool.